### PR TITLE
update the api upgrade version scope to be 50.0 - 200.0

### DIFF
--- a/messages/messages.json
+++ b/messages/messages.json
@@ -1,8 +1,8 @@
 {
   "pluginTitle": "Salesforce API Version Upgrade Tool",
-  "metadatatype": "Select metadata type. Possible values: classes/triggers/pages/components/aura/lwc",
-  "sourceapi": "The API version threshold from which you wish to upgrade. Minimum: 50, Maximum: 99, Default: 50",
-  "targetapi": "The API version you want to upgrade to. Minimum: 50, Maximum: 100, Default: 51",
+  "metadatatype": "Select metadata type. pick one or some of them, e.g: classes or classes/triggers; Possible values: classes/triggers/pages/components/aura/lwc/flows",
+  "sourceapi": "The API version threshold from which you wish to upgrade. Minimum: 10, Maximum: 199, Default: 50",
+  "targetapi": "The API version you want to upgrade to. Minimum: 51, Maximum: 200, Default: 51",
   "path": "The path to your src folder",
   "prefix": "Metadata filename prefix. E.g. PSM for PSM_New_Shipment.cls. Default: none(all files)",
   "dryrun": "If present will only output the files changed without actually changing them"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfdx-apiversion-upgrade",
-  "description": "Helps in upgrading salesforce api version for all metadata files",
-  "version": "1.0.0",
+  "description": "Helps in upgrading salesforce api version for all metadata files, up to 200.0 apiversion",
+  "version": "1.0.1",
   "author": "sieanloong",
   "bugs": "https://github.com/Sieanloong/sfdx-apiversion-upgrade/issues",
   "dependencies": {
@@ -50,8 +50,8 @@
       "metadatautil": {
         "description": "Metadata utility tools"
       },
-      "metadatautil:upgradeapiversion": {
-        "description": "Updates metadata API version"
+      "metadatautil:set-api-version": {
+        "description": "set metadata API version from origin version to target version."
       }
     },
     "devPlugins": [

--- a/src/commands/metadatautil/upgradeapiversion.ts
+++ b/src/commands/metadatautil/upgradeapiversion.ts
@@ -29,7 +29,7 @@ export default class UpgradeAPIVersion extends SfdxCommand {
           console.log(
             "Metadata of type: " +
               val +
-              " is not supported. Possible values are: classes/triggers/pages/components/aura/lwc"
+              " is not supported. Possible values are: classes/triggers/pages/components/aura/lwc/flows"
           );
           process.exit();
         } else {
@@ -46,13 +46,13 @@ export default class UpgradeAPIVersion extends SfdxCommand {
       char: "s",
       description: messages.getMessage("sourceapi"),
       min: 10,
-      max: 99,
+      max: 199,
     }),
     targetversion: flags.number({
       char: "t",
       description: messages.getMessage("targetapi"),
-      min: 50,
-      max: 100,
+      min: 51,
+      max: 200,
     }),
     fileprefix: flags.string({
       char: "x",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -5,6 +5,7 @@ export const acceptedMetadata = [
   "triggers",
   "aura",
   "lwc",
+  "flows"
 ];
 
 export const DEFAULT_SOURCE_API_VERSION = 50;

--- a/src/services/modifymetaxmlfile.ts
+++ b/src/services/modifymetaxmlfile.ts
@@ -37,19 +37,18 @@ export class ModifyMetaXMLFile {
       if (metadata[i] == "lwc") {
         selectedFiles.push(pathModule.join(path, "lwc", "**", fileName));
       }
+      if (metadata[i] == "flows") {
+        selectedFiles.push(pathModule.join(path, "flows", "**", fileName));
+      }
     }
 
     // Set the Regex to match the max requested API version
-    let firstDigit = sourceversion.toString()[0];
-    let secondDigit = sourceversion.toString()[1];
-    let regex = `<apiVersion>([0-${
-      +firstDigit - 1
-    }][0-9]|[${firstDigit}-${firstDigit}][0-${+secondDigit}]).0</apiVersion>`;
+    //let regex = `<apiVersion>${sourceversion}.0</apiVersion>`;
 
     // Constructing the options parameter to be passed to replace-in-file module
     let options = {
       files: selectedFiles,
-      from: new RegExp(regex, "g"),
+      from: new RegExp( `<apiVersion>${sourceversion}.0</apiVersion>`, "g"),
       to: `<apiVersion>${targetversion}.0</apiVersion>`,
       dry: dryrun,
     };


### PR DESCRIPTION
update the message for min / max version support
update version to 1.0.1
add flows metadata type and extend upgrade version range to 50.0 - 200.0